### PR TITLE
タスク更新機能（タスク完了/未完了含む）の追加

### DIFF
--- a/src/features/task/components/TaskList.tsx
+++ b/src/features/task/components/TaskList.tsx
@@ -2,9 +2,10 @@ import { Box, Center, Checkbox, Spinner, Text, VStack } from "@chakra-ui/react";
 import { useEffect } from "react";
 import { useTaskController } from "../hooks";
 import { Task } from "../types/task";
+import { UpdateTaskButton } from "./UpdateTaskButton";
 
 export const TaskList = () => {
-  const { tasks, fetchTasks } = useTaskController();
+  const { tasks, fetchTasks, updateTask } = useTaskController();
 
   useEffect(() => {
     fetchTasks();
@@ -45,8 +46,17 @@ export const TaskList = () => {
             borderRadius="md"
             display="flex"
             alignItems="center"
+            onClick={async () =>
+              await updateTask(task.id, task.title, !task.completed)
+            }
           >
-            <Checkbox isChecked={task.completed} mr={3} />
+            <Checkbox
+              isChecked={task.completed}
+              onChange={async () =>
+                await updateTask(task.id, task.title, !task.completed)
+              }
+              mr={3}
+            />
             <Box flex="1">
               <Text fontSize="sm" color="gray.500">
                 ID: {task.id}
@@ -55,6 +65,7 @@ export const TaskList = () => {
                 {task.title}
               </Text>
             </Box>
+            <UpdateTaskButton task={task} />
           </Box>
         ))}
       </VStack>

--- a/src/features/task/components/UpdateTaskButton.tsx
+++ b/src/features/task/components/UpdateTaskButton.tsx
@@ -1,0 +1,86 @@
+import {
+  Button,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useToast,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import { useTaskController } from "../hooks";
+import { Task } from "../types/task";
+
+export const UpdateTaskButton = ({ task }: { task: Task }) => {
+  const { updateTask, fetchTasks } = useTaskController();
+  const [isOpen, setIsOpen] = useState(false);
+  const [taskTitle, setTaskTitle] = useState(task.title);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const toast = useToast();
+
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => {
+    setIsOpen(false);
+    setError(null);
+  };
+
+  const handleUpdateTask = async () => {
+    if (!taskTitle) return;
+    setIsLoading(true);
+    try {
+      await updateTask(task.id, taskTitle, task.completed);
+      await fetchTasks();
+      toast({
+        title: "タスクが更新されました",
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
+      handleClose();
+    } catch (e) {
+      setError("タスクの更新に失敗しました。");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Button onClick={handleOpen}>編集</Button>
+      <Modal isOpen={isOpen} onClose={handleClose} isCentered>
+        <ModalOverlay />
+        <ModalContent m={4}>
+          <ModalHeader>タスクを更新</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Input
+              placeholder="タスクのタイトルを入力"
+              value={taskTitle}
+              onChange={(e) => setTaskTitle(e.target.value)}
+            />
+            {error && <Text color="red.500">{error}</Text>}
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              colorScheme="blue"
+              mr={3}
+              onClick={handleUpdateTask}
+              isLoading={isLoading}
+              isDisabled={!taskTitle}
+            >
+              更新
+            </Button>
+            <Button variant="ghost" onClick={handleClose}>
+              キャンセル
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};

--- a/src/features/task/hooks.ts
+++ b/src/features/task/hooks.ts
@@ -32,6 +32,7 @@ export const useTaskController = (
   tasks: Loadable<Task[]>;
   fetchTasks: () => Promise<void>;
   addTask: (title: string) => Promise<void>;
+  updateTask: (id: number, title: string, completed: boolean) => Promise<void>;
 } => {
   const [, setTasks] = useAtom(tasksAtom);
   const [tasks] = useAtom(loadableTasksAtom);
@@ -79,9 +80,30 @@ export const useTaskController = (
     }
   };
 
+  /**
+   * タスクを更新する
+   * @param {number} id - 更新するタスクのID
+   * @param {string} title - 更新後のタスクのタイトル
+   * @param {boolean} completed - タスクの完了状態
+   * @returns {Promise<void>}
+   */
+  const updateTask = async (
+    id: number,
+    title: string,
+    completed: boolean
+  ): Promise<void> => {
+    try {
+      await taskRepository.update(id, title, completed);
+      await fetchTasks();
+    } catch (e) {
+      Logger.error(e);
+    }
+  };
+
   return {
     tasks,
     fetchTasks,
     addTask,
+    updateTask,
   };
 };

--- a/src/features/task/repository/task-repository-impl.ts
+++ b/src/features/task/repository/task-repository-impl.ts
@@ -93,4 +93,50 @@ export class TaskRepositoryImpl implements TaskRepository {
       throw appError;
     }
   }
+
+  async update(id: number, title: string, completed: boolean): Promise<Task> {
+    try {
+      const body = {
+        title,
+        completed,
+      };
+      const response = await axios.put(`${Config.apiHost}/todos/${id}`, body);
+
+      if (response.status === 200) {
+        const updatedTask: Task = response.data;
+        Logger.debug(updatedTask);
+        return updatedTask;
+      } else {
+        throw new AppError(`予期しないステータスコード: ${response.status}`);
+      }
+    } catch (error) {
+      let appError: AppError;
+
+      if (axios.isAxiosError(error)) {
+        const axiosError = error as AxiosError;
+        if (axiosError.response) {
+          if (axiosError.response.status === 400) {
+            appError = new ValidationError(
+              "タスクの更新に失敗しました。入力データが不正です。"
+            );
+          } else {
+            appError = new AppError(
+              `タスクの更新中にエラーが発生しました。ステータスコード: ${axiosError.response.status}`
+            );
+          }
+        } else {
+          appError = new AppError(
+            "タスクの更新中にネットワークエラーが発生しました。"
+          );
+        }
+      } else {
+        appError = new UnknownError(
+          "タスクの更新中に予期しないエラーが発生しました。"
+        );
+      }
+
+      Logger.error(appError);
+      throw appError;
+    }
+  }
 }

--- a/src/features/task/repository/task-repository.ts
+++ b/src/features/task/repository/task-repository.ts
@@ -16,4 +16,13 @@ export interface TaskRepository {
    * @returns {Promise<Task>} 追加されたタスクを含むPromise
    */
   add(title: string): Promise<Task>;
+
+  /**
+   * タスクを更新する
+   * @param {number} id - 更新するタスクのID
+   * @param {string} title - 更新後のタスクのタイトル
+   * @param {boolean} completed - タスクの完了状態
+   * @returns {Promise<Task>} 更新されたタスクを含むPromise
+   */
+  update(id: number, title: string, completed: boolean): Promise<Task>;
 }


### PR DESCRIPTION
## 変更内容

<!-- 変更の概要を簡潔に記述してください -->

1. 一覧表示している各タスクの末尾に『編集』ボタンを追加。
2. 『編集』ボタンをクリックすると、更新用のモーダル（以下、更新モーダル）が表示される。
3. 更新モーダルには以下の項目を表示させてください。
   a. 『タイトル』：テキストボックス
   - 初期値は該当タスクの『タイトル』と同じ値とする。
     b. 『キャンセル』：ボタン
   - ボタンを押下すると更新モーダルが閉じられる
     c. 『更新』：ボタン
   - ボタンを押下すると、API にタスク更新リクエストが投げられる。
4. タスクの更新に成功した場合は、更新モーダルが閉じ、一覧に表示されているタスクが更新後の値となっている。
5. タスクの更新に失敗した場合は、更新モーダルの最下部にエラーメッセージを表示させる。


1. 一覧表示しているタスクの『完了』チェックボックス
   a. チェックを入れると
   - 完了タスクとして API リクエストを送信。
     b. チェック済み状態でチェックを外すと
   - 未完了タスクとして API リクエストを送信。
2. API リクエストに失敗した場合
   a. トーストで失敗した旨を表示すること。
   b. 完了状態は元に戻してください。（例：未完了 → 完了へ失敗した場合は、未完了のまま）


## 関連する Issue

<!-- 関連するIssueがある場合は、ここにリンクを記載してください -->

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] 機能改善
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他（詳細を記載してください）

## チェックリスト

- [ ] テストを追加または更新しました
- [ ] ドキュメントを更新しました（必要な場合）
- [ ] コードレビューの準備ができています

## スクリーンショット（必要な場合）

<!-- UI変更がある場合は、変更前後のスクリーンショットを添付してください -->

![スクリーンショット 2024-09-25 15 16 21](https://github.com/user-attachments/assets/2fd40204-2034-43fc-a09d-8d25c5a54972)

## 追加のコメント

<!-- その他、レビュアーに伝えたい情報があればここに記載してください -->
