### PR TITLE
タスク削除機能の追加

### DIFF
--- a/src/features/task/components/DeleteTaskButton.tsx
+++ b/src/features/task/components/DeleteTaskButton.tsx
@@ -1,0 +1,38 @@
+import { Button, useToast } from "@chakra-ui/react";
+import { useState } from "react";
+import { useTaskController } from "../hooks";
+import { Task } from "../types/task";
+
+export const DeleteTaskButton = ({ task }: { task: Task }) => {
+  const { removeTask } = useTaskController();
+  const [isLoading, setIsLoading] = useState(false);
+  const toast = useToast();
+
+  const handleDeleteTask = async () => {
+    setIsLoading(true);
+    try {
+      await removeTask(task.id);
+      toast({
+        title: "タスクが削除されました",
+        status: "success",
+        duration: 3000,
+        isClosable: true,
+      });
+    } catch (e) {
+      toast({
+        title: "タスクの削除に失敗しました",
+        status: "error",
+        duration: 3000,
+        isClosable: true,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Button colorScheme="red" onClick={handleDeleteTask} isLoading={isLoading}>
+      削除
+    </Button>
+  );
+};

--- a/src/features/task/components/TaskList.tsx
+++ b/src/features/task/components/TaskList.tsx
@@ -2,6 +2,7 @@ import { Box, Center, Checkbox, Spinner, Text, VStack } from "@chakra-ui/react";
 import { useEffect } from "react";
 import { useTaskController } from "../hooks";
 import { Task } from "../types/task";
+import { DeleteTaskButton } from "./DeleteTaskButton";
 import { UpdateTaskButton } from "./UpdateTaskButton";
 
 export const TaskList = () => {
@@ -66,6 +67,7 @@ export const TaskList = () => {
               </Text>
             </Box>
             <UpdateTaskButton task={task} />
+            <DeleteTaskButton task={task} />
           </Box>
         ))}
       </VStack>

--- a/src/features/task/hooks.ts
+++ b/src/features/task/hooks.ts
@@ -33,6 +33,7 @@ export const useTaskController = (
   fetchTasks: () => Promise<void>;
   addTask: (title: string) => Promise<void>;
   updateTask: (id: number, title: string, completed: boolean) => Promise<void>;
+  removeTask: (id: number) => Promise<void>;
 } => {
   const [, setTasks] = useAtom(tasksAtom);
   const [tasks] = useAtom(loadableTasksAtom);
@@ -100,10 +101,25 @@ export const useTaskController = (
     }
   };
 
+  /**
+   * タスクを削除する
+   * @param {number} id - 削除するタスクのID
+   * @returns {Promise<void>}
+   */
+  const removeTask = async (id: number): Promise<void> => {
+    try {
+      await taskRepository.remove(id);
+      await fetchTasks();
+    } catch (e) {
+      Logger.error(e);
+    }
+  };
+
   return {
     tasks,
     fetchTasks,
     addTask,
     updateTask,
+    removeTask,
   };
 };

--- a/src/features/task/repository/task-repository-impl.ts
+++ b/src/features/task/repository/task-repository-impl.ts
@@ -139,4 +139,38 @@ export class TaskRepositoryImpl implements TaskRepository {
       throw appError;
     }
   }
+
+  async remove(id: number): Promise<void> {
+    try {
+      const response = await axios.delete(`${Config.apiHost}/todos/${id}`);
+
+      if (response.status === 200) {
+        Logger.debug(`タスクが削除されました: ID ${id}`);
+      } else {
+        throw new AppError(`予期しないステータスコード: ${response.status}`);
+      }
+    } catch (error) {
+      let appError: AppError;
+
+      if (axios.isAxiosError(error)) {
+        const axiosError = error as AxiosError;
+        if (axiosError.response) {
+          appError = new AppError(
+            `タスクの削除中にエラーが発生しました。ステータスコード: ${axiosError.response.status}`
+          );
+        } else {
+          appError = new AppError(
+            "タスクの削除中にネットワークエラーが発生しました。"
+          );
+        }
+      } else {
+        appError = new UnknownError(
+          "タスクの削除中に予期しないエラーが発生しました。"
+        );
+      }
+
+      Logger.error(appError);
+      throw appError;
+    }
+  }
 }

--- a/src/features/task/repository/task-repository.ts
+++ b/src/features/task/repository/task-repository.ts
@@ -25,4 +25,11 @@ export interface TaskRepository {
    * @returns {Promise<Task>} 更新されたタスクを含むPromise
    */
   update(id: number, title: string, completed: boolean): Promise<Task>;
+
+  /**
+   * タスクを削除する
+   * @param {number} id - 削除するタスクのID
+   * @returns {Promise<void>} 削除されたタスクを含むPromise
+   */
+  remove(id: number): Promise<void>;
 }


### PR DESCRIPTION
## 変更内容

<!-- 変更の概要を簡潔に記述してください -->

1. 一覧表示している各タスクの末尾に『削除』ボタンを追加。
2. 『削除』ボタンをクリックすると、該当のタスクが削除され、削除した旨をトーストで表示すること。また、一覧からも消えること。
3. 削除に失敗した場合は、トーストで削除に失敗した旨を表示すること。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] 機能改善
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] その他（詳細を記載してください）

## チェックリスト

- [ ] テストを追加または更新しました
- [ ] ドキュメントを更新しました（必要な場合）
- [ ] コードレビューの準備ができています

## スクリーンショット（必要な場合）

<!-- UI変更がある場合は、変更前後のスクリーンショットを添付してください -->

![スクリーンショット 2024-09-25 15 23 55](https://github.com/user-attachments/assets/d7feb38a-affb-4295-a352-fe7a411f88c3)


## 追加のコメント

<!-- その他、レビュアーに伝えたい情報があればここに記載してください -->
